### PR TITLE
Fix the jumping of content because of search

### DIFF
--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -1,4 +1,8 @@
+#search-hits-wrapper {
+  display: none;
+}
 #search-searchbar {
+  height: 46px;
   margin: 20px 10px 20px 0px;
 }
 /* Search header */


### PR DESCRIPTION
This should fix the jumping of content.

What id does is completely hiding the `<div>` that will contain the search results until we type something (it was previously showing it, then hiding it, resulting in the flicker).

I also set a fixed height to the element holding the searchbar to reduce the flickering of the sidebar as well.

It does not fix the issue with `.join`, I'm on it. It seems that the plugin is indexing some files it should not (dynamic redirects).